### PR TITLE
Add Encrypted.PDF in the clean words

### DIFF
--- a/lib/Scan.pm
+++ b/lib/Scan.pm
@@ -451,6 +451,7 @@ sub scan {
             'OK',
             'Zip module failure',
             "RAR module failure",
+            'Encrypted.PDF',
             'Encrypted.RAR',
             'Encrypted.Zip',
             'Empty file',


### PR DESCRIPTION
Encrypted PDFs are marked by ClamAV as threats and Clamtk does not offer the option to ignore this on the GUI (#66 ):
```
/path/to/encrypted-doc.pdf: Heuristics.Encrypted.PDF FOUND
```

Unfortunately the flags passed on `/usr/bin/clamscan` are hardcoded in the `Scan.pm` source file and there is no way to change them. This PR provides a quick & dirty fix and treats encrypted PDFs similar to encrypted ZIP/RAR files by ignoring the warning and modifying the `clean_words` variable on the [aforementioned file](https://github.com/dave-theunsub/clamtk/blob/996ca5590b5be838a0616c17bda9461d0ca297ac/lib/Scan.pm#L454).
