### PR TITLE
Fix appdata file

### DIFF
--- a/com.github.davetheunsub.clamtk.appdata.xml
+++ b/com.github.davetheunsub.clamtk.appdata.xml
@@ -2,6 +2,7 @@
 <!-- Copyright 2021 Dave M <dave.nerd@gmail.com> -->
 <component type="desktop-application">
  <id>com.github.davetheunsub.clamtk</id>
+ <launchable type="desktop-id">clamtk.desktop</launchable>
  <metadata_license>FSFAP</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>ClamTk</name>
@@ -96,7 +97,7 @@
  <update_contact>dave.nerd@gmail.com</update_contact>
  <url type="homepage">https://github.com/dave-theunsub/clamtk/</url>
  <url type="bugtracker">https://bugzilla.redhat.com/buglist.cgi?quicksearch=clamtk</url>
-  <url type="translate">https://translations.launchpad.net/clamtk</url>
-  <url type="faq">https://github.com/dave-theunsub/clamtk/blob/master/README.md</url>
+ <url type="translate">https://translations.launchpad.net/clamtk</url>
+ <url type="faq">https://github.com/dave-theunsub/clamtk/blob/master/README.md</url>
 
 </component>


### PR DESCRIPTION
Fixes #130.

This fixes the appdata file. The icon can be fixed later by changing [this path](https://github.com/dave-theunsub/clamtk/blob/14d03fdf2e5dfb6b9cd099e6272b27bc5b6cb8ea/lib/App.pm#L41) + changing [icon install path](https://src.fedoraproject.org/rpms/clamtk/blob/rawhide/f/clamtk.spec#_31) and [images dir](https://src.fedoraproject.org/rpms/clamtk/blob/rawhide/f/clamtk.spec#_62) in the Fedora spec file.

/cc @dave-theunsub