### PR TITLE
Change default clamtk user directory to .config/clamtk

### DIFF
--- a/lib/App.pm
+++ b/lib/App.pm
@@ -49,7 +49,7 @@ sub get_path {
         ( -d $path->{directory} . '/.clamtk' ) ? $path->{directory} . '/.clamtk'
       : ( defined $ENV{CLAMTK_HOME} )          ? $ENV{CLAMTK_HOME}
       : ( defined $ENV{XDG_CONFIG_HOME} ) ? $ENV{XDG_CONFIG_HOME} . '/clamtk'
-      :                                     $path->{directory} . '/.clamtk';
+      :                                     $path->{directory} . '/.config/clamtk';
 
     # Trash directory - main
     $path->{trash_dir} = $path->{directory} . '/.local/share/Trash';


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) states that If `$XDG_CONFIG_HOME` is either not set or empty (as it is on many linux distros), a default equal to `$HOME/.config` should be used, so ideally the clamtk user directory should default to `~/.config/clamtk` (unless `~/.clamtk` already exists), not `~/.clamtk`